### PR TITLE
Extended routes black list with PWA7 routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.9.1] - 2024-10-08
+## Added
+- Extended `searchBarBlacklist` with new "PWA 7" routes
+
 ## [1.9.0] - 2024-07-31
 ## Fixed
 - improved component behavior when search suggestion is selected

--- a/extension-config.json
+++ b/extension-config.json
@@ -61,7 +61,22 @@
         "/login",
         "/checkout",
         "/item/:productId/gallery/:slide",
-        "/scanner"
+        "/scanner",
+        "/privacy-settings",
+        "/register",
+        "/forgot-password",
+        "/storefinder",
+        "/orders/:orderId",
+        "/order-details/:orderNumber",
+        "/account/profile/contact",
+        "/account/:tab",
+        "/account",
+        "/checkout",
+        "/checkout/guest",
+        "/checkout/guest/payment",
+        "/checkout/addresses/:type",
+        "/checkout/addresses/:type/contact",
+        "/checkout/success"
       ],
       "params": {
         "type": "json",


### PR DESCRIPTION
This pull request is about to extend the `searchBarBlacklist` extension config setting with routes from PWA7 that are not supposed to show the search bar.