### PR TITLE
Add store details page to blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.11.0] - 2025-03-06
+## Added
+- Added store detail page to blacklist config
+
 ## [1.10.1] - 2025-01-06
 ## Fixed
 - Updated some prop type definitions of components

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Add the persistent-search-bar extension to your Shopgate Connect deployment conf
 (...)
   {
     "id": "@shopgate-project/persistent-search-bar",
-    "version": "1.1.0"
+    "version": "1.11.0"
   }
 (...)
 ```
@@ -33,7 +33,7 @@ Set the following value in your Shopgate Connect Admin:
 
 * searchFieldLabel - (string) Add a custom label to the search field
 
-* showLastSearchQuery - (boolean) Display the last search query in the search field on the results page 
+* showLastSearchQuery - (boolean) Display the last search query in the search field on the results page
 
 ## Default searchBarBlacklist value
 ```json
@@ -42,11 +42,27 @@ Set the following value in your Shopgate Connect Admin:
     "/browse",
     "/cart",
     "/category/:categoryId/filter",
+    "/category/:categoryId/all/filter",
     "/search/filter",
     "/login",
-    "/checkout",
     "/item/:productId/gallery/:slide",
-    "/scanner"
+    "/scanner",
+    "/privacy-settings",
+    "/register",
+    "/forgot-password",
+    "/storefinder",
+    "/orders/:orderId",
+    "/order-details/:orderNumber",
+    "/account/profile/contact",
+    "/account/:tab",
+    "/account",
+    "/checkout",
+    "/checkout/guest",
+    "/checkout/guest/payment",
+    "/checkout/addresses/:type",
+    "/checkout/addresses/:type/contact",
+    "/checkout/success",
+    "/store-details/:code"
   ],
   "barBgColor": "",
   "bgColor": "",

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.1",
+  "version": "1.11.0",
   "id": "@shopgate-project/persistent-search-bar",
   "components": [
     {
@@ -76,7 +76,8 @@
         "/checkout/guest/payment",
         "/checkout/addresses/:type",
         "/checkout/addresses/:type/contact",
-        "/checkout/success"
+        "/checkout/success",
+        "/store-details/:code"
       ],
       "params": {
         "type": "json",

--- a/extension-config.json
+++ b/extension-config.json
@@ -59,7 +59,6 @@
         "/category/:categoryId/all/filter",
         "/search/filter",
         "/login",
-        "/checkout",
         "/item/:productId/gallery/:slide",
         "/scanner",
         "/privacy-settings",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "classnames": "^2.2.5",
     "coveralls": "^3.0.1",
     "eslint": "^5.12.0",
     "jest": "^25.1.0",
@@ -39,13 +40,5 @@
   },
   "dependencies": {
     "@shopgate-ps/pwa-extension-kit": "^0.6.0"
-  },
-  "peerDependencies": {
-    "@shopgate/engage": "^6.18.7-beta.7 || ^7.6.0-beta.3",
-    "@shopgate/pwa-common": "^6.18.7-beta.7 || ^7.6.0-beta.3",
-    "@shopgate/pwa-common-commerce": "^6.18.7-beta.7 || ^7.6.0-beta.3",
-    "@shopgate/pwa-core": "^6.18.7-beta.7 || ^7.6.0-beta.3",
-    "@shopgate/pwa-ui-shared": "^6.18.7-beta.7 || ^7.6.0-beta.3",
-    "classnames": "^2.2.5"
   }
 }


### PR DESCRIPTION
We added the store details page to the default blacklist so the search bar does not show up on that page.